### PR TITLE
Changed implementation to use a single struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0]
+- Reworked the crate to use only a single Struct `ConstClosure`.
+- Allow borrowing tuples of up to 12 references (Currently only of the same mutability).
+- Updated the docs for the new version.
+- Breaking: Removed the old Types (`ConstFnClosure`, `ConstFnMutClosure`, `ConstFnOnceClosure`).
+- Breaking: Require the Captured Data and Arguments of the implementation function to be Tuples for consistency.
+
 ## [0.2.3] - 2022-11-10
 
 - Minor doc improvements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0]
+## [0.3.0] - 2022-11-22
 - Reworked the crate to use only a single Struct `ConstClosure`.
 - Allow borrowing tuples of up to 12 references (Currently only of the same mutability).
 - Updated the docs for the new version.
@@ -47,7 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Initial release.
 
-[Unreleased]: https://github.com/ink-feather-org/const_closure/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/ink-feather-org/const_closure/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/ink-feather-org/const_closure/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/ink-feather-org/const_closure/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/ink-feather-org/const_closure/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/ink-feather-org/const_closure/compare/v0.2.0...v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "const_closure"
-version = "0.2.3"
+version = "0.3.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = [

--- a/README.md
+++ b/README.md
@@ -10,30 +10,56 @@
 
 This crate allows you to create types which represent closures in const contexts.
 
-To do this simply create an instance of one of the provided closure helpers: `Const{Fn, FnMut, FnOnce}Closure`
-with their associated `new` function.
+To do this simply create an instance of the provided closure helper: `ConstClosure`
+with the associated `new` function.
 
-A closure helper instance gets the data to capture (owned for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
-and the closure function to execute.
+A closure helper instance gets the data to capture as a tuple of same ownership (Owned, Mut or ref) and the implementation function to execute.
 
-The closure function must be a `const fn` that gets the captured state (owned for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
+The implementation function must be a `const fn` that gets the captured state (a tuple of: owned values for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
 and a tuple representing the arguments of the closure.
 
-A closure helper instance returns the return value of the closure function.
+A closure helper instance returns the return value of the closure function on call.
 
 ## Example
 ```rust
-#![feature(const_mut_refs)]
-use const_closure::ConstFnMutClosure;
-const fn imp(state: &mut i32, (arg,): (i32,)) -> i32 {
-  *state += arg;
-  *state
-}
-let mut i = 5;
-let mut cl = ConstFnMutClosure::new(&mut i, imp);
+#![feature(const_trait_impl)]
+#![feature(const_mut_refs)] // Only required for the FnMut example
 
-assert!(7 == cl(2));
-assert!(8 == cl(1));
+use const_closure::ConstClosure;
+
+// FnOnce:
+const _: () = {
+  const fn imp((state,): (i32,), (arg,): (i32,)) -> i32 {
+    state + arg
+  }
+  let cl = ConstClosure::new((5,), imp);
+  assert!(7 == cl(2));
+};
+
+// FnMut:
+const _: () = {
+  const fn imp((state,): (&mut i32,), (arg,): (i32,)) -> i32 {
+    *state += arg;
+    *state
+  }
+  let mut i = 5;
+  let mut cl = ConstClosure::new((&mut i,), imp);
+
+  assert!(7 == cl(2));
+  assert!(8 == cl(1));
+};
+
+// Fn:
+const _: () = {
+  const fn imp((state,): (&i32,), (arg,): (i32,)) -> i32 {
+    *state + arg
+  }
+  let i = 5;
+  let mut cl = ConstClosure::new((&i,), imp);
+  assert!(7 == cl(2));
+  assert!(8 == cl(3));
+  assert!(6 == cl(1));
+};
 ```
 
 Note: The `const_closure` macro has been removed in favour of the new generic based approach.

--- a/src/closure_type.rs
+++ b/src/closure_type.rs
@@ -30,14 +30,22 @@ impl<CapturedData: Tuple, Function> ConstClosure<CapturedData, Function> {
 }
 
 macro_rules! impl_const_closure {
-  ($T:ident) => {
-    impl_const_closure!(@impl $T);
-};
-  ($T:ident $($U:ident)+) => {
-    impl_const_closure!($($U)+);
-    impl_const_closure!(@impl $T $( $U )+);
+  ($A:ident) => {
+    impl_const_closure!(@impl [
+      #[doc = "This trait is implemented for tuples up to twelve items long."]] $A);
   };
-  (@impl $($var:ident)+) => {
+  ($A:ident $B:ident) => {
+    impl_const_closure!($B);
+    impl_const_closure!(@impl [
+      #[doc = "This trait is implemented for tuples up to twelve items long."]] $A $B);
+  };
+  ($T:ident $B:ident $($U:ident)+) => {
+    impl_const_closure!($B $($U)+);
+    impl_const_closure!(@impl
+      [#[doc(hidden)]] $T $B $( $U )+);
+  };
+  (@impl $([#[$meta:meta]])? $($var:ident)+) => {
+    $(#[$meta])?
     impl<$($var,)+ ClosureArguments: Tuple, Function, ClosureReturnValue> const
       FnOnce<ClosureArguments> for ConstClosure<($($var,)+), Function>
     where
@@ -51,6 +59,7 @@ macro_rules! impl_const_closure {
         (self.func)(self.data, args)
       }
     }
+    $(#[$meta])?
     impl<'a, $($var,)+ ClosureArguments: Tuple, Function, ClosureReturnValue> const
       FnMut<ClosureArguments> for ConstClosure<($(&'a mut $var,)+), Function>
     where
@@ -63,6 +72,7 @@ macro_rules! impl_const_closure {
         (self.func)(($($var,)*), args)
       }
     }
+    $(#[$meta])?
     impl<'a, $($var,)+ ClosureArguments: Tuple, Function, ClosureReturnValue> const
     FnMut<ClosureArguments> for ConstClosure<($(&'a $var,)+), Function>
     where
@@ -73,6 +83,7 @@ macro_rules! impl_const_closure {
         (self.func)(self.data, args)
       }
     }
+    $(#[$meta])?
     impl<'a, $($var,)+ ClosureArguments: Tuple, Function, ClosureReturnValue> const
       Fn<ClosureArguments> for ConstClosure<($(&'a $var,)+), Function>
     where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,13 +29,13 @@ A closure helper instance returns the return value of the closure function.
 ## Example
 ```rust
 #![feature(const_mut_refs)]
-use const_closure::ConstFnMutClosure;
-const fn imp(state: &mut i32, (arg,): (i32,)) -> i32 {
+use const_closure::ConstClosure;
+const fn imp((state,): (&mut i32,), (arg,): (i32,)) -> i32 {
   *state += arg;
   *state
 }
 let mut i = 5;
-let mut cl = ConstFnMutClosure::new(&mut i, imp);
+let mut cl = ConstClosure::new((&mut i,), imp);
 
 assert!(7 == cl(2));
 assert!(8 == cl(1));
@@ -67,7 +67,7 @@ conditions.
 */
 
 mod closure_type;
-pub use closure_type::{ConstFnClosure, ConstFnMutClosure, ConstFnOnceClosure};
+pub use closure_type::ConstClosure;
 
 #[cfg(test)]
 #[allow(clippy::trivially_copy_pass_by_ref)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,30 +15,56 @@
 
 This crate allows you to create types which represent closures in const contexts.
 
-To do this simply create an instance of one of the provided closure helpers: `Const{Fn, FnMut, FnOnce}Closure`
-with their associated `new` function.
+To do this simply create an instance of the provided closure helper: `ConstClosure`
+with the associated `new` function.
 
-A closure helper instance gets the data to capture (owned for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
-and the closure function to execute.
+A closure helper instance gets the data to capture as a tuple of same ownership (Owned, Mut or ref) and the implementation function to execute.
 
-The closure function must be a `const fn` that gets the captured state (owned for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
+The implementation function must be a `const fn` that gets the captured state (a tuple of: owned values for `FnOnce`, `&mut` for `FnMut` and `&` for `Fn`)
 and a tuple representing the arguments of the closure.
 
-A closure helper instance returns the return value of the closure function.
+A closure helper instance returns the return value of the closure function on call.
 
 ## Example
 ```rust
-#![feature(const_mut_refs)]
-use const_closure::ConstClosure;
-const fn imp((state,): (&mut i32,), (arg,): (i32,)) -> i32 {
-  *state += arg;
-  *state
-}
-let mut i = 5;
-let mut cl = ConstClosure::new((&mut i,), imp);
+#![feature(const_trait_impl)]
+#![feature(const_mut_refs)] // Only required for the FnMut example
 
-assert!(7 == cl(2));
-assert!(8 == cl(1));
+use const_closure::ConstClosure;
+
+// FnOnce:
+const _: () = {
+  const fn imp((state,): (i32,), (arg,): (i32,)) -> i32 {
+    state + arg
+  }
+  let cl = ConstClosure::new((5,), imp);
+  assert!(7 == cl(2));
+};
+
+// FnMut:
+const _: () = {
+  const fn imp((state,): (&mut i32,), (arg,): (i32,)) -> i32 {
+    *state += arg;
+    *state
+  }
+  let mut i = 5;
+  let mut cl = ConstClosure::new((&mut i,), imp);
+
+  assert!(7 == cl(2));
+  assert!(8 == cl(1));
+};
+
+// Fn:
+const _: () = {
+  const fn imp((state,): (&i32,), (arg,): (i32,)) -> i32 {
+    *state + arg
+  }
+  let i = 5;
+  let mut cl = ConstClosure::new((&i,), imp);
+  assert!(7 == cl(2));
+  assert!(8 == cl(3));
+  assert!(6 == cl(1));
+};
 ```
 
 Note: The `const_closure` macro has been removed in favour of the new generic based approach.

--- a/src/test.rs
+++ b/src/test.rs
@@ -3,7 +3,7 @@ use core::{
   marker::{Destruct, Tuple},
 };
 
-use crate::ConstFnMutClosure;
+use crate::ConstClosure;
 
 #[test]
 fn test1() {
@@ -18,7 +18,7 @@ fn test1() {
   }
 
   const fn imp<T: ~const Destruct, F, K: ~const PartialOrd + ~const Destruct>(
-    f: &mut F,
+    (f,): (&mut F,),
     (a, b): (&T, &T),
   ) -> Option<Ordering>
   where
@@ -26,7 +26,7 @@ fn test1() {
   {
     f(a).partial_cmp(&f(b))
   }
-  let cl = ConstFnMutClosure::new(&mut f, imp); //|f, (a, b): (&i32, &i32)| None);
+  let cl = ConstClosure::new((&mut f,), imp);
 
   consume(cl);
 }
@@ -59,7 +59,7 @@ const fn test2() {
 #[test]
 const fn test3() {
   const fn imp<T, F, K: ~const PartialOrd + ~const Destruct>(
-    f: &mut F,
+    (f,): (&mut F,),
     (a, b): (&T, &T),
   ) -> Option<core::cmp::Ordering>
   where
@@ -71,7 +71,7 @@ const fn test3() {
     3
   }
   let mut tr = trans::<i32>;
-  let mut cl = ConstFnMutClosure::new(&mut tr, imp);
+  let mut cl = ConstClosure::new((&mut tr,), imp);
 
   const fn consume<T, F>(_: F)
   where
@@ -89,7 +89,7 @@ const fn test3() {
   const_is_sorted_by(&mut cl);
 
   const fn imp2<T, F, K: ~const PartialOrd + ~const Destruct>(
-    f: &mut F,
+    (f,): (&mut F,),
     (a, b): (&T, &T),
   ) -> Option<core::cmp::Ordering>
   where
@@ -101,5 +101,5 @@ const fn test3() {
     5
   }
   let mut f = testx::<i32>;
-  const_is_sorted_by(ConstFnMutClosure::new(&mut f, imp2));
+  const_is_sorted_by(ConstClosure::new((&mut f,), imp2));
 }


### PR DESCRIPTION
... instead of One for each `Fn` trait.
Bump version as this has breaking changes. 
The added tests demonstrate usages enabled through this PR.